### PR TITLE
Add a failing test for reliance on Object.keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "homepage": "https://github.com/jo/docuri",
   "devDependencies": {
+    "shuffle-array": "^0.1.0",
     "tap": "^0.4.8"
   }
 }

--- a/test/named-parameter-order-test.js
+++ b/test/named-parameter-order-test.js
@@ -1,0 +1,36 @@
+var shuffle = require('shuffle-array');
+var test = require('tap').test;
+var docuri = require('..');
+
+var simulateWrongOrderObjectKeys = function(cb){
+  var orig = Object.keys;
+  Object.keys = function(obj){
+    var keys = orig(obj);
+    var real = keys.toString();
+    while (real === keys.toString())
+      shuffle(keys);
+    return keys;
+  };
+  try {
+    cb();
+  } catch (err) {
+    Object.keys = orig;
+    throw err;
+  }
+  Object.keys = orig;
+};
+
+test('named parameters are not reliant on Object.keys order', function(t) {
+  var page = docuri.route('page/:foo/:bar/:quux/:baz');
+
+  simulateWrongOrderObjectKeys(function(){
+    t.deepEqual(
+      page('page/1/2/3/4'),
+      { foo: '1', bar: '2', quux: '3', baz: '4' },
+      'does not rely on Object.keys order',
+      { todo: true }
+    );
+  });
+
+  t.end();
+});


### PR DESCRIPTION
The current code relies on Object keys to be [kept in insertion order](https://github.com/jo/docuri/blob/824d69fd08edb8c819c4bfe557c0271aed281fce/index.js#L67). This is absolutely not alright, as the specification claims the object key order is completely undefined.
v8 is [officially not caring](https://code.google.com/p/v8/issues/detail?id=164) about the order of keys. Fixing this requires more work, for now here's the failing test marked as todo.
