### PR TITLE
optional parameter with a trailing slash

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ function insertParameters(route, obj) {
 
   // massage optional parameter
   return str
-    .replace(/\(\/\)(\/|$)/g, '$1')
+    .replace(/\(\/\)/g, '')
     .replace(/[)(]/g, '');
 }
 

--- a/test/optional-parameter-test.js
+++ b/test/optional-parameter-test.js
@@ -22,3 +22,14 @@ test('surrounded optional parameter', function(t) {
 
   t.end();
 });
+
+test('optional parameter with trailing slash', function(t) {
+  var page = docuri.route('(:id/)page');
+
+  t.deepEqual(page('page'), {}, 'parsed page returns empty object');
+  t.deepEqual(page('mypage/page'), { id: 'mypage' }, 'parsed page has "id" set to "mypage"');
+  t.equal(page(), 'page', 'stringified empty page results in "page"');
+  t.equal(page({ id: 'mypage' }), 'mypage/page', 'stringified page results in "mypage/page"');
+
+  t.end();
+});


### PR DESCRIPTION
empty optional groups get only removed if they are followed by a slash eg `(/)/foo`  becomes `/foo` but `(/)foo` becomes `/foo` any reason for that behaviour?