### PR TITLE
Allow inserting falsy values, excluding undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ function insertParameters(route, obj) {
 
   Object.keys(route.keys).forEach(function(key) {
     var k = key.substr(1);
-    var value = obj[k] || '';
+    var value = (obj[k] !== undefined) ? obj[k] : '';
 
     if (Array.isArray(value)) {
       value = value.map(encodeURIComponent).join('/');

--- a/test/named-parameter-test.js
+++ b/test/named-parameter-test.js
@@ -10,6 +10,18 @@ test('named parameter', function(t) {
   t.end();
 });
 
+test('insert falsy parameter values', function(t) {
+  var page = docuri.route('page/:id');
+
+  t.deepEqual(page({}), 'page/', 'stringifies without id');
+  t.deepEqual(page({id: undefined}), 'page/', 'stringifies without id');
+  t.deepEqual(page({id: 0}), 'page/0', 'inserts "0"');
+  t.deepEqual(page({id: false}), 'page/false', 'inserts "false"');
+  t.deepEqual(page({id: null}), 'page/null', 'inserts "null"');
+
+  t.end();
+});
+
 test('two named parameters', function(t) {
   var content = docuri.route('page/:page_id/content/:id');
 


### PR DESCRIPTION
That behaviour was a bit surprising:

```js
var page = docuri.route('page/:id');

page('/page/0') // result: {id: 0}
page({id: 0})   // result:  "/page/"
```

After patch, it would filter only `undefined`.